### PR TITLE
feat!: switch back to `bon`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 rust-version = "1.75.0"
 
 [dependencies]
+bon = "2.2.0"
 compact_str = { version = "0.8.0", features = ["serde"] }
 linkify = "0.10.0"
 petgraph = "0.6.5"
@@ -21,7 +22,6 @@ serde_path_to_error = "0.1.16"
 thiserror = "1"
 time = { version = "0.3", features = ["formatting", "parsing", "serde", "macros"] }
 tower = { version = "0.5.0", features = ["util"] }
-typed-builder = "0.20.0"
 url = "2.5"
 
 [dev-dependencies]

--- a/examples/get_league_matches.rs
+++ b/examples/get_league_matches.rs
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
     };
     let get_league_matches = GetLeagueMatches::builder()
         .id(id)
-        .status_opt(status)
+        .maybe_status(status)
         .build();
 
     let client = Client::new(reqwest::Client::new(), token)?;

--- a/src/endpoint/all/leagues.rs
+++ b/src/endpoint/all/leagues.rs
@@ -9,11 +9,10 @@ use crate::{
 crate::endpoint::list_endpoint!(ListLeagues("/leagues") => League);
 crate::endpoint::get_endpoint!(GetLeague("/leagues") => League);
 
-#[derive(Debug, Clone, PartialEq, Eq, typed_builder::TypedBuilder)]
+#[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 pub struct GetLeagueMatches<'a> {
-    #[builder(setter(into))]
+    #[builder(into)]
     id: Identifier<'a>,
-    #[builder(default, setter(strip_option(fallback = status_opt)))]
     status: Option<EventStatus>,
     #[builder(default)]
     options: CollectionOptions,
@@ -36,9 +35,9 @@ impl Sealed for GetLeagueMatches<'_> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, typed_builder::TypedBuilder)]
+#[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 pub struct ListLeagueSeries<'a> {
-    #[builder(setter(into))]
+    #[builder(into)]
     id: Identifier<'a>,
     #[builder(default)]
     options: CollectionOptions,

--- a/src/endpoint/all/series.rs
+++ b/src/endpoint/all/series.rs
@@ -9,11 +9,10 @@ use crate::{
 crate::endpoint::multi_list_endpoint!(ListSeries("/series") => Series);
 crate::endpoint::get_endpoint!(GetSeries("/series") => Series);
 
-#[derive(Debug, Clone, PartialEq, Eq, typed_builder::TypedBuilder)]
+#[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 pub struct ListSeriesMatches<'a> {
-    #[builder(setter(into))]
+    #[builder(into)]
     id: Identifier<'a>,
-    #[builder(default, setter(strip_option(fallback = status_opt)))]
     status: Option<EventStatus>,
     #[builder(default)]
     options: CollectionOptions,
@@ -36,9 +35,9 @@ impl Sealed for ListSeriesMatches<'_> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, typed_builder::TypedBuilder)]
+#[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 pub struct ListSeriesTournaments<'a> {
-    #[builder(setter(into))]
+    #[builder(into)]
     id: Identifier<'a>,
     #[builder(default)]
     options: CollectionOptions,

--- a/src/endpoint/all/tournament.rs
+++ b/src/endpoint/all/tournament.rs
@@ -45,9 +45,9 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, typed_builder::TypedBuilder)]
+#[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 pub struct ListTournamentMatches<'a> {
-    #[builder(setter(into))]
+    #[builder(into)]
     pub id: Identifier<'a>,
     #[builder(default)]
     pub options: CollectionOptions,
@@ -69,9 +69,9 @@ impl Sealed for ListTournamentMatches<'_> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, typed_builder::TypedBuilder)]
+#[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 pub struct ListTournamentTeams<'a> {
-    #[builder(setter(into))]
+    #[builder(into)]
     pub id: Identifier<'a>,
     #[builder(default)]
     pub options: CollectionOptions,
@@ -118,9 +118,9 @@ where
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, typed_builder::TypedBuilder)]
+#[derive(Debug, Clone, Eq, PartialEq, bon::Builder)]
 pub struct GetTournamentStandings<'a> {
-    #[builder(setter(into))]
+    #[builder(into)]
     pub id: Identifier<'a>,
     #[builder(default)]
     pub options: CollectionOptions,

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -463,9 +463,8 @@ pub(crate) use list_endpoint;
 
 macro_rules! multi_list_endpoint {
     ($name:ident($path:expr) => $response:ty) => {
-        #[derive(Debug, Clone, Eq, PartialEq, Default, typed_builder::TypedBuilder)]
+        #[derive(Debug, Clone, Eq, PartialEq, Default, ::bon::Builder)]
         pub struct $name {
-            #[builder(default, setter(strip_option(fallback = status_opt)))]
             pub status: ::std::option::Option<$crate::model::EventStatus>,
             #[builder(default)]
             pub options: $crate::endpoint::CollectionOptions,


### PR DESCRIPTION
Reverts #13 following lint and MSRV fixes in `bon` 2.1 and new derive API in `bon` 2.2
