### PR TITLE
fix: pagination `Links` header parsing bug

### DIFF
--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -181,10 +181,12 @@ impl CollectionOptions {
         }
 
         if let Some(page) = self.page {
-            query.append_pair("page[number]", &page.to_compact_string());
+            // query.append_pair("page[number]", &page.to_compact_string());
+            query.append_pair("page", &page.to_compact_string());
         }
         if let Some(per_page) = self.per_page {
-            query.append_pair("page[size]", &per_page.to_compact_string());
+            // query.append_pair("page[size]", &per_page.to_compact_string());
+            query.append_pair("per_page", &per_page.to_compact_string());
         }
     }
 

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -253,8 +253,8 @@ static KEY_REGEX: OnceLock<Regex> = OnceLock::new();
 
 fn get_key_regex() -> &'static Regex {
     // Matches "filter[...]", "search[...]", "range[...]", "sort"
-    // https://regex101.com/r/ZPylAq/1
-    KEY_REGEX.get_or_init(|| Regex::new(r"([a-z]+)(\[(.+)])?").unwrap())
+    // https://regex101.com/r/3snY41/1
+    KEY_REGEX.get_or_init(|| Regex::new(r"([a-z_]+)(\[(.+)])?").unwrap())
 }
 
 /// Represents a response from a collection endpoint.

--- a/tests/leagues.rs
+++ b/tests/leagues.rs
@@ -32,8 +32,8 @@ async fn test_list_leagues_options() {
     let client = MockClient::new(include_bytes!("./fixtures/list_leagues.json"))
         .expect(Expectation::Method(reqwest::Method::GET))
         .expect(Expectation::Path("/leagues"))
-        .expect(Expectation::Query("page[number]", "1"))
-        .expect(Expectation::Query("page[size]", "10"))
+        .expect(Expectation::Query("page", "1"))
+        .expect(Expectation::Query("per_page", "10"))
         .expect(Expectation::Query("filter[name]", "A1 Esport Valorant Cup"))
         .expect(Expectation::Query("sort", "name"));
 


### PR DESCRIPTION
The PandaScore servers seem to accept headers in the form of
`page[number]=x` when requesting. However, this seems to cause bugs when
reading the `Links` header as the server will have both `page[number]`
and `page` in the returned link.

The solution here is to not use `page[number]` at all.
