### PR TITLE
fix: increase player age bitsize to `u32`

### DIFF
--- a/src/model/player.rs
+++ b/src/model/player.rs
@@ -24,7 +24,7 @@ pub struct CompactPlayer {
     pub active: bool,
     /// Age of the player, null if unknown. When `birthday` is null, age is an approxiamation.
     /// Note: this field is only present for users running the Historical plan or up.
-    pub age: Option<u8>,
+    pub age: Option<u32>,
     /// Birthday of the player.
     /// Note: this field is only present for users running the Historical plan or up.
     #[serde(with = "birthday_format", default)]


### PR DESCRIPTION
Sometimes the PandaScore API will return the player's birth year instead
of their age. This prevents the client from erroring when that happens.
